### PR TITLE
Fix possible TypeError when oldValue does not exists

### DIFF
--- a/src/DebounceInput.js
+++ b/src/DebounceInput.js
@@ -82,7 +82,7 @@ const DebounceInput = React.createClass({
     }
 
     // If user hits backspace and goes below minLength consider it cleaning the value
-    if (value.length < oldValue.length) {
+    if (oldValue && value.length < oldValue.length) {
       this.notify('');
     }
   },


### PR DESCRIPTION
Remove error: `Uncaught TypeError: Cannot read property 'length' of undefined` when started enter keys and `minLength` was not yet reached.