### PR TITLE
can now set value prop to parent's state and an option to only notify on user input changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Function called when value is changed (debounced)
 
 #### `value`: PropTypes.string (default: '')
 
-Initial value
+Value displayed by the input box. It will only update the contents if the value changes.
 
 
 #### `minLength`: PropTypes.number (default: 2)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ Notification of current value will be sent immediately by hitting `Enter` key. E
 *NOTE* if `onKeyDown` callback prop was present, it will be still invoked transparently.
 
 
+#### `onlyNotifyOnUserInput`: PropTypes.bool (default: false)
+
+Notification of current value will not occur if the props value changes it, it will only occur due to user input.
+
+
 #### Arbitrary props will be transferred to rendered `<input>`
 
 ```js

--- a/src/DebounceInput.js
+++ b/src/DebounceInput.js
@@ -18,7 +18,8 @@ const DebounceInput = React.createClass({
     return {
       minLength: 0,
       debounceTimeout: 100,
-      forceNotifyByEnter: true
+      forceNotifyByEnter: true,
+      value: ''
     };
   },
 
@@ -36,7 +37,7 @@ const DebounceInput = React.createClass({
 
 
   componentWillReceiveProps({value}) {
-    if (typeof value !== 'undefined' && this.state.value !== value) {
+    if (typeof value !== 'undefined' && this.props.value !== value) {
       this.setState({value});
     }
   },

--- a/src/DebounceInput.js
+++ b/src/DebounceInput.js
@@ -10,7 +10,8 @@ const DebounceInput = React.createClass({
     value: React.PropTypes.string,
     minLength: React.PropTypes.number,
     debounceTimeout: React.PropTypes.number,
-    forceNotifyByEnter: React.PropTypes.bool
+    forceNotifyByEnter: React.PropTypes.bool,
+    onlyNotifyOnUserInput: React.PropTypes.bool
   },
 
 
@@ -19,6 +20,7 @@ const DebounceInput = React.createClass({
       minLength: 0,
       debounceTimeout: 100,
       forceNotifyByEnter: true,
+      onlyNotifyOnUserInput: false,
       value: ''
     };
   },
@@ -26,6 +28,7 @@ const DebounceInput = React.createClass({
 
   getInitialState() {
     return {
+      isUserInput: false,
       value: this.props.value
     };
   },
@@ -46,9 +49,9 @@ const DebounceInput = React.createClass({
   shouldComponentUpdate,
 
 
-  componentWillUpdate({minLength, debounceTimeout}, {value}) {
+  componentWillUpdate({minLength, debounceTimeout, onlyNotifyOnUserInput}, {value, isUserInput}) {
     this.maybeUpdateNotifier(debounceTimeout);
-    this.maybeNotify(minLength, value);
+    this.maybeNotify(isUserInput, minLength, onlyNotifyOnUserInput, value);
   },
 
 
@@ -70,12 +73,18 @@ const DebounceInput = React.createClass({
   },
 
 
-  maybeNotify(minLength, value) {
+  maybeNotify(isUserInput, minLength, onlyNotifyOnUserInput, value) {
     const {value: oldValue} = this.state;
 
     if (value === oldValue) {
       return;
     }
+
+    if (onlyNotifyOnUserInput && !isUserInput) {
+      return;
+    }
+
+    this.setState({isUserInput: false});
 
     if (value.length >= minLength) {
       this.notify(value);
@@ -102,13 +111,13 @@ const DebounceInput = React.createClass({
 
 
   onChange({target: {value}}) {
-    this.setState({value});
+    this.setState({value, isUserInput: true});
   },
 
 
   render() {
     const {onChange, value: v, minLength,
-      debounceTimeout, forceNotifyByEnter, ...props} = this.props;
+      debounceTimeout, forceNotifyByEnter, onlyNotifyOnUserInput, ...props} = this.props;
     const onKeyDown = forceNotifyByEnter ? {
       onKeyDown: event => {
         if (event.key === 'Enter') {

--- a/src/example/App.js
+++ b/src/example/App.js
@@ -37,6 +37,10 @@ const App = React.createClass({
     this.setState({key});
   },
 
+  setTextBoxValueToASDF() {
+    this.setState({value: 'ASDF'});
+  },
+
 
   render() {
     return (
@@ -66,12 +70,14 @@ const App = React.createClass({
         <div>
           <h2>Test</h2>
           <DebounceInput
+            value={this.state.value}
             minLength={this.state.minLength}
             debounceTimeout={this.state.indefinite ? -1 : this.state.debounceTimeout}
             onChange={this.onChange}
             onKeyDown={this.onKeyDown} />
           <p>Value: {this.state.value}</p>
           <p>Key pressed: {this.state.key}</p>
+          <button onClick={this.setTextBoxValueToASDF}>Set input to ASDF</button>
         </div>
       </div>
     );

--- a/src/example/App.js
+++ b/src/example/App.js
@@ -8,7 +8,11 @@ const App = React.createClass({
       value: '',
       minLength: 0,
       debounceTimeout: 300,
-      indefinite: false
+      indefinite: false,
+      history: [''],
+      historyIndex: 0,
+      lastNotifiedValue: '',
+      onlyNotifyOnUserInput: true
     };
   },
 
@@ -27,9 +31,20 @@ const App = React.createClass({
     this.setState({indefinite: checked});
   },
 
+  onChangeNotifyUserInput({target: {checked}}) {
+    this.setState({onlyNotifyOnUserInput: checked});
+  },
+
 
   onChange(value) {
-    this.setState({value});
+    const historyIndex = this.state.historyIndex + 1;
+
+    this.setState({
+      value,
+      lastNotifiedValue: value,
+      historyIndex,
+      history: this.state.history.slice(0, historyIndex).concat(value)
+    });
   },
 
 
@@ -37,8 +52,28 @@ const App = React.createClass({
     this.setState({key});
   },
 
-  setTextBoxValueToASDF() {
-    this.setState({value: 'ASDF'});
+  setValueFromHistory(newIndex) {
+    let historyIndex = newIndex;
+
+    if (historyIndex < 0) {
+      historyIndex = 0;
+    } else if (historyIndex >= this.state.history.length) {
+      historyIndex = this.state.history.length - 1;
+    }
+
+    if (historyIndex === 0 && this.state.history.length === 0) {
+      return;
+    }
+
+    this.setState({value: this.state.history[historyIndex], historyIndex});
+  },
+
+  redo() {
+    this.setValueFromHistory(this.state.historyIndex + 1);
+  },
+
+  undo() {
+    this.setValueFromHistory(this.state.historyIndex - 1);
   },
 
 
@@ -65,6 +100,14 @@ const App = React.createClass({
               type="checkbox"
               onChange={this.onChangeIndefiniteTimeout} />
           </label>
+
+          <label>
+            Notifications for User Input Only:&nbsp;
+            <input
+              type="checkbox"
+              checked={this.state.onlyNotifyOnUserInput}
+              onChange={this.onChangeNotifyUserInput} />
+          </label>
         </div>
 
         <div>
@@ -74,10 +117,26 @@ const App = React.createClass({
             minLength={this.state.minLength}
             debounceTimeout={this.state.indefinite ? -1 : this.state.debounceTimeout}
             onChange={this.onChange}
+            onlyNotifyOnUserInput={this.state.onlyNotifyOnUserInput}
             onKeyDown={this.onKeyDown} />
-          <p>Value: {this.state.value}</p>
+          <button onClick={this.undo}>Undo</button>
+          <button onClick={this.redo}>Redo</button>
+          <p>Undo Stack: {
+            this.state.history
+              .map(s => `"${s}"`)
+              .splice(0, this.state.historyIndex)
+              .reverse()
+              .join(', ')}
+          </p>
+          <p>Current Value: {this.state.value}</p>
+          <p>Redo Stack: {
+            this.state.history
+              .map(s => `"${s}"`)
+              .splice(this.state.historyIndex + 1)
+              .join(', ')}
+          </p>
           <p>Key pressed: {this.state.key}</p>
-          <button onClick={this.setTextBoxValueToASDF}>Set input to ASDF</button>
+          <p>Last Change Notification Value: {this.state.lastNotifiedValue}</p>
         </div>
       </div>
     );


### PR DESCRIPTION
This change allows the input box's value to be changed via it's props rather than only taking an initial value. It also adds an option to only notify on user input changes and not due to the props changes to allow for creating a history of user inputs allowing for undo and redo.