### PR TITLE
Adding forceNotifyOnBlur prop and functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Notification of current value will be sent immediately by hitting `Enter` key. E
 
 *NOTE* if `onKeyDown` callback prop was present, it will be still invoked transparently.
 
+#### `forceNotifyOnBlur`: PropTypes.bool (default: true)
+
+Notification of current value will be sent immediately when focus leaves the input field. Enabled by-default. Notification value follows the same rule as with debounced notification, so if Length is less, then `minLength` - empty value `''` will be sent back.
+
+*NOTE* if `onBlur` prop was present, it will be still invoked transparently.
+
 
 #### Arbitrary props will be transferred to rendered `<input>`
 

--- a/src/DebounceInput.js
+++ b/src/DebounceInput.js
@@ -7,10 +7,12 @@ const DebounceInput = React.createClass({
   propTypes: {
     onChange: React.PropTypes.func.isRequired,
     onKeyDown: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
     value: React.PropTypes.string,
     minLength: React.PropTypes.number,
     debounceTimeout: React.PropTypes.number,
-    forceNotifyByEnter: React.PropTypes.bool
+    forceNotifyByEnter: React.PropTypes.bool,
+    forceNotifyOnBlur: React.PropTypes.bool
   },
 
 
@@ -18,7 +20,8 @@ const DebounceInput = React.createClass({
     return {
       minLength: 0,
       debounceTimeout: 100,
-      forceNotifyByEnter: true
+      forceNotifyByEnter: true,
+      forceNotifyOnBlur: true
     };
   },
 
@@ -105,7 +108,7 @@ const DebounceInput = React.createClass({
 
   render() {
     const {onChange, value: v, minLength,
-      debounceTimeout, forceNotifyByEnter, ...props} = this.props;
+      debounceTimeout, forceNotifyByEnter, forceNotifyOnBlur, onBlur, ...props} = this.props;
     const onKeyDown = forceNotifyByEnter ? {
       onKeyDown: event => {
         if (event.key === 'Enter') {
@@ -118,11 +121,19 @@ const DebounceInput = React.createClass({
       }
     } : {};
 
+    const wrappedOnBlur = event => {
+      this.forceNotify(event);
+      if (onBlur) {
+        onBlur(event);
+      }
+    };
+
     return (
       <input type="text"
         {...props}
         value={this.state.value}
         onChange={this.onChange}
+        onBlur={forceNotifyOnBlur ? wrappedOnBlur : onBlur}
         {...onKeyDown} />
     );
   }


### PR DESCRIPTION
Thoughts on this?  

I'm working on a project where the debounced input has a blur handler that triggers a rerender.  If the user moves off of the input field before a notify occurs, they loose their most recent changes since the input value is instantly updated to the props value.

This will fix that issue, and possibly remove other race conditions where forms are submitted before the input notifies. 