### PR TITLE
Allow omitting onChange and use as uncontrolled component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/react-component-template/.eslintrc"
+  "extends": "./node_modules/react-component-template/.eslintrc",
+  "rules": {
+    "no-empty-function": 0
+  }
 }

--- a/src/example/App/Uncontrolled.js
+++ b/src/example/App/Uncontrolled.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+import DebounceInput from '../..';
+import css from './App.css';
+
+
+const Uncontrolled = React.createClass({
+  getInitialState() {
+    return {
+      value: '',
+      key: ''
+    };
+  },
+
+
+  onRef(ref) {
+    this.ref = ReactDom.findDOMNode(ref);
+  },
+
+
+  onKeyDown({key}) {
+    if (key === 'Enter') {
+      this.setState({key, value: this.ref.value})
+    } else {
+      this.setState({key})
+    }
+  },
+
+
+  render() {
+    const {
+      value, key
+    } = this.state;
+
+    return (
+      <div>
+        <DebounceInput
+          ref={this.onRef}
+          onKeyDown={this.onKeyDown} />
+        <p>Value: {value}</p>
+        <p>Key pressed: {key}</p>
+      </div>
+
+    );
+  }
+});
+
+
+export default Uncontrolled;

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -3,6 +3,7 @@ import Controllable from './Controllable';
 import Customizable from './Customizable';
 import UndoRedo from './UndoRedo';
 import Textarea from './Textarea';
+import Uncontrolled from './Uncontrolled';
 import css from './App.css';
 
 
@@ -27,6 +28,11 @@ const App = () => (
     <section className={css.section}>
       <h2>Example 4. Debounced Textarea</h2>
       <Textarea />
+    </section>
+
+    <section className={css.section}>
+      <h2>Example 5. Uncontrolled input</h2>
+      <Uncontrolled />
     </section>
   </div>
 );


### PR DESCRIPTION
Need to check downstream to make sure it is not breaking change.

NOTE: when using `ref` `findDOMNode` is necessary since Debounce is wrapper component and it's own ref is not a DOM element