### PR TITLE
Fix bug with sticky onChange props

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -74,10 +74,10 @@ export const DebounceInput = React.createClass({
       this.notify = debounce(this.doNotify, debounceTimeout);
     }
   },
-  
-  
+
+
   doNotify(...args) {
-    this.props.onChange(...args)
+    this.props.onChange(...args);
   },
 
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -69,10 +69,15 @@ export const DebounceInput = React.createClass({
     if (debounceTimeout < 0) {
       this.notify = () => null;
     } else if (debounceTimeout === 0) {
-      this.notify = this.props.onChange;
+      this.notify = this.doNotify;
     } else {
-      this.notify = debounce(this.props.onChange, debounceTimeout);
+      this.notify = debounce(this.doNotify, debounceTimeout);
     }
+  },
+  
+  
+  doNotify(...args) {
+    this.props.onChange(...args)
   },
 
 
@@ -82,12 +87,12 @@ export const DebounceInput = React.createClass({
     }
 
     const {value} = this.state;
-    const {minLength, onChange} = this.props;
+    const {minLength} = this.props;
 
     if (value.length >= minLength) {
-      onChange(event);
+      this.doNotify(event);
     } else {
-      onChange({...event, target: {...event.target, value}});
+      this.doNotify({...event, target: {...event.target, value}});
     }
   },
 


### PR DESCRIPTION
I noticed some weird behavior when I had the onChange handlers changing dynamically, where it would only invoke the first onChange function.

To fix, I just made the `doNotify()` function that calls `this.props.onChange`. This way old references to the old debounced onChange handler don't hang around and it always calls the current onChange.

The downside to this approach is if the onChange handler changes between an event and the debounced call invocation, then it will invoke the new handler, not the one that was set when the event first took place. If you feel this is a bad tradeoff, feel free to close this PR.
