### PR TITLE
Added support for defaultValue prop

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -5,6 +5,10 @@ import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin
 
 export const DebounceInput = React.createClass({
   propTypes: {
+    defaultValue: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number
+    ]),
     element: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
     type: React.PropTypes.string,
     onChange: React.PropTypes.func.isRequired,
@@ -35,7 +39,7 @@ export const DebounceInput = React.createClass({
 
   getInitialState() {
     return {
-      value: this.props.value || ''
+      value: this.props.value || this.props.defaultValue || ''
     };
   },
 

--- a/src/example/App/Customizable.js
+++ b/src/example/App/Customizable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import DebounceInput from '../..';
 import css from './App.css';
 
+const defaultValue = '123';
 
 const Customizable = React.createClass({
   getInitialState() {
@@ -77,12 +78,14 @@ const Customizable = React.createClass({
         </div>
 
         <DebounceInput
+          defaultValue={defaultValue}
           forceNotifyByEnter={forceNotifyByEnter}
           forceNotifyOnBlur={forceNotifyOnBlur}
           minLength={minLength}
           debounceTimeout={infinite ? -1 : debounceTimeout}
           onChange={e => this.setState({value: e.target.value})}
           onKeyDown={e => this.setState({key: e.key})} />
+        <p>Default value: {defaultValue}</p>
         <p>Value: {value}</p>
         <p>Key pressed: {key}</p>
       </div>


### PR DESCRIPTION
This PR enables passing a `defaultValue` prop which will be used during initial render,
as described in [React documentation](https://facebook.github.io/react/docs/forms.html#default-value).
This PR was born from [this comment ](https://github.com/nkbt/react-debounce-input/issues/15#issuecomment-242969664).
