### PR TITLE
Fix warnings with latest react

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "react"
   ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,11 @@
 {
   "extends": "./node_modules/react-component-template/.eslintrc",
+  "plugins": [
+    "babel"
+  ],
   "rules": {
+    "babel/no-invalid-this": 2,
+    "no-invalid-this": 0,
     "react/jsx-sort-props": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "react": "^0.14 || ^15"
   },
   "dependencies": {
-    "lodash.debounce": "^3 || ^4"
+    "lodash.debounce": "^3 || ^4",
+    "prop-types": "^15"
   },
   "devDependencies": {
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "react-component-template": "0.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   },
   "homepage": "https://github.com/nkbt/react-debounce-input",
   "peerDependencies": {
-    "react": "^0.14 || ^15"
+    "react": ">=15.3"
   },
   "dependencies": {
     "lodash.debounce": "^3 || ^4",
-    "prop-types": "^15"
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "eslint-plugin-babel": "^4.1.1",
     "react-component-template": "0.1.9"
   }
 }

--- a/src/Component.js
+++ b/src/Component.js
@@ -1,48 +1,52 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 
 
-export const DebounceInput = React.createClass({
-  propTypes: {
-    element: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
-    type: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    onKeyDown: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
+export class DebounceInput extends React.PureComponent {
+  static propTypes = {
+    element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    type: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func,
+    onBlur: PropTypes.func,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
     ]),
-    minLength: React.PropTypes.number,
-    debounceTimeout: React.PropTypes.number,
-    forceNotifyByEnter: React.PropTypes.bool,
-    forceNotifyOnBlur: React.PropTypes.bool
-  },
+    minLength: PropTypes.number,
+    debounceTimeout: PropTypes.number,
+    forceNotifyByEnter: PropTypes.bool,
+    forceNotifyOnBlur: PropTypes.bool
+  };
 
 
-  getDefaultProps() {
-    return {
-      element: 'input',
-      type: 'text',
-      minLength: 0,
-      debounceTimeout: 100,
-      forceNotifyByEnter: true,
-      forceNotifyOnBlur: true
+  static defaultProps = {
+    element: 'input',
+    type: 'text',
+    minLength: 0,
+    debounceTimeout: 100,
+    forceNotifyByEnter: true,
+    forceNotifyOnBlur: true
+  };
+
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: props.value || ''
     };
-  },
 
+    this.isDebouncing = false;
 
-  getInitialState() {
-    return {
-      value: this.props.value || ''
-    };
-  },
+    this.onChange = this.onChange.bind(this);
+  }
 
 
   componentWillMount() {
     this.createNotifier(this.props.debounceTimeout);
-  },
+  }
 
 
   componentWillReceiveProps({value, debounceTimeout}) {
@@ -55,19 +59,15 @@ export const DebounceInput = React.createClass({
     if (debounceTimeout !== this.props.debounceTimeout) {
       this.createNotifier(debounceTimeout);
     }
-  },
-
-
-  shouldComponentUpdate,
+  }
 
 
   componentWillUnmount() {
     if (this.notify.flush) {
       this.notify.flush();
     }
-  },
+  }
 
-  isDebouncing: false,
 
   createNotifier(debounceTimeout) {
     if (debounceTimeout < 0) {
@@ -85,13 +85,14 @@ export const DebounceInput = React.createClass({
         debouncedChangeFunc(event);
       };
     }
-  },
+  }
+
 
   doNotify(...args) {
     const {onChange} = this.props;
 
     onChange(...args);
-  },
+  }
 
 
   forceNotify(event) {
@@ -112,7 +113,7 @@ export const DebounceInput = React.createClass({
     } else {
       this.doNotify({...event, target: {...event.target, value}});
     }
-  },
+  }
 
 
   onChange(event) {
@@ -133,7 +134,7 @@ export const DebounceInput = React.createClass({
         this.notify({...event, target: {...event.target, value: ''}});
       }
     });
-  },
+  }
 
 
   render() {
@@ -181,4 +182,4 @@ export const DebounceInput = React.createClass({
       ...maybeOnBlur
     });
   }
-});
+}

--- a/src/Component.js
+++ b/src/Component.js
@@ -39,8 +39,6 @@ export class DebounceInput extends React.PureComponent {
     };
 
     this.isDebouncing = false;
-
-    this.onChange = this.onChange.bind(this);
   }
 
 
@@ -69,7 +67,7 @@ export class DebounceInput extends React.PureComponent {
   }
 
 
-  createNotifier(debounceTimeout) {
+  createNotifier = debounceTimeout => {
     if (debounceTimeout < 0) {
       this.notify = () => null;
     } else if (debounceTimeout === 0) {
@@ -88,14 +86,14 @@ export class DebounceInput extends React.PureComponent {
   }
 
 
-  doNotify(...args) {
+  doNotify = (...args) => {
     const {onChange} = this.props;
 
     onChange(...args);
   }
 
 
-  forceNotify(event) {
+  forceNotify = event => {
     if (!this.isDebouncing) {
       return;
     }
@@ -116,7 +114,7 @@ export class DebounceInput extends React.PureComponent {
   }
 
 
-  onChange(event) {
+  onChange = event => {
     event.persist();
 
     const oldValue = this.state.value;


### PR DESCRIPTION
Stop using React.PropTypes in favor of 'prop-types'.
Stop using React.creatClass in favor of subclassing PureComponent.