### PR TITLE
Set notify.flush so that debouncedChangeFunc occurs on component unmount

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -82,6 +82,7 @@ export class DebounceInput extends React.PureComponent {
         this.isDebouncing = true;
         debouncedChangeFunc(event);
       };
+      this.notify.flush = debouncedChangeFunc.flush;
     }
   };
 


### PR DESCRIPTION
The debounce timeout is not being cleared when component is unmounted.

`this.notify.flush` is not defined when `componentWillUnmount` is called.

This PR ensures that`debouncedChangeFunc.flush` is assigned to `this.notify.flush` inside of `createNotifier`.