### PR TITLE
Add inputRef prop to pass as ref to input element

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Notification of current value will be sent immediately by hitting `Enter` key. E
 
 Same as `forceNotifyByEnter`, but notification will be sent when focus leaves the input field.
 
+#### `inputRef`: PropTypes.func (default: undefined)
+
+Will pass `ref={inputRef}` to generated input element. We needed to rename `ref` to `inputRef` since `ref` is a special prop in React and cannot be passed to children. 
+
+See [./example/Ref.js](./example/Ref.js) for usage example.
+
 #### Arbitrary props will be transferred to rendered `<input>`
 
 ```js

--- a/example/App.js
+++ b/example/App.js
@@ -3,6 +3,7 @@ import {Controllable} from './Controllable';
 import {Customizable} from './Customizable';
 import {UndoRedo} from './UndoRedo';
 import {Textarea} from './Textarea';
+import {Ref} from './Ref';
 
 
 export const App = () => (
@@ -26,6 +27,11 @@ export const App = () => (
     <section className="section">
       <h2>Example 4. Debounced Textarea</h2>
       <Textarea />
+    </section>
+
+    <section className="section">
+      <h2>Example 5. Custom ref</h2>
+      <Ref />
     </section>
   </div>
 );

--- a/example/Ref.js
+++ b/example/Ref.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {DebounceInput} from '../src';
+
+
+export class Ref extends React.Component {
+  state = {
+    value: '',
+    key: undefined
+  };
+
+
+  render() {
+    const {
+      value,
+      key
+    } = this.state;
+
+    return (
+      <div>
+        <div className="config">
+          <label className="label">
+            <button onClick={() => this.ref.focus()}>Focus, please</button>
+          </label>
+
+          <label className="label">
+            <button onClick={() => this.ref.blur()}>Blur, please</button>
+          </label>
+        </div>
+
+        <DebounceInput
+          inputRef={ref => {
+            this.ref = ref;
+          }}
+          onChange={e => this.setState({value: e.target.value})}
+          onKeyDown={e => this.setState({key: e.key})} />
+        <p>Value: {value}</p>
+        <p>Key pressed: {key}</p>
+      </div>
+
+    );
+  }
+}


### PR DESCRIPTION
Fixes #65 putting focus on a DebounceInput
Fixes #77 How to set focus automatically

- [x] Add `inputRef` prop and pass it down as `ref` to generated input
- [x] Add `Ref` example with blur/focus
- [x] Update README with new prop explanation and link to example
- [x] Also cache internal blur/keydown callbacks as instance functions