### PR TITLE
Add non-required debounceOptions prop object and forward it to lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "lodash.debounce": "^4",
-    "prop-types": "^15"
+    "prop-types": "^15",
+    "shallowequal": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/Component.js
+++ b/src/Component.js
@@ -16,6 +16,7 @@ export class DebounceInput extends React.PureComponent {
     ]),
     minLength: PropTypes.number,
     debounceTimeout: PropTypes.number,
+    debounceOptions: PropTypes.object,
     forceNotifyByEnter: PropTypes.bool,
     forceNotifyOnBlur: PropTypes.bool,
     inputRef: PropTypes.func
@@ -30,6 +31,7 @@ export class DebounceInput extends React.PureComponent {
     value: undefined,
     minLength: 0,
     debounceTimeout: 100,
+    debounceOptions: undefined,
     forceNotifyByEnter: true,
     forceNotifyOnBlur: true,
     inputRef: undefined
@@ -48,19 +50,30 @@ export class DebounceInput extends React.PureComponent {
 
 
   componentWillMount() {
-    this.createNotifier(this.props.debounceTimeout);
+    const {
+      debounceTimeout,
+      debounceOptions
+    } = this.props;
+    this.createNotifier(debounceTimeout, debounceOptions);
   }
 
 
-  componentWillReceiveProps({value, debounceTimeout}) {
+  componentWillReceiveProps({value, debounceTimeout, debounceOptions}) {
     if (this.isDebouncing) {
       return;
     }
     if (typeof value !== 'undefined' && this.state.value !== value) {
       this.setState({value});
     }
-    if (debounceTimeout !== this.props.debounceTimeout) {
-      this.createNotifier(debounceTimeout);
+    const {
+      debounceTimeout: debounceTimeoutCurrent,
+      debounceOptions: debounceOptionsCurrent
+    } = this.props;
+    if (
+      debounceTimeout !== debounceTimeoutCurrent || 
+      debounceOptions !== debounceOptionsCurrent
+    ) {
+      this.createNotifier(debounceTimeout, debounceOptions);
     }
   }
 
@@ -117,7 +130,7 @@ export class DebounceInput extends React.PureComponent {
   };
 
 
-  createNotifier = debounceTimeout => {
+  createNotifier = (debounceTimeout, debounceOptions) => {
     if (debounceTimeout < 0) {
       this.notify = () => null;
     } else if (debounceTimeout === 0) {
@@ -126,7 +139,7 @@ export class DebounceInput extends React.PureComponent {
       const debouncedChangeFunc = debounce(event => {
         this.isDebouncing = false;
         this.doNotify(event);
-      }, debounceTimeout);
+      }, debounceTimeout, debounceOptions);
 
       this.notify = event => {
         this.isDebouncing = true;

--- a/src/Component.js
+++ b/src/Component.js
@@ -70,7 +70,7 @@ export class DebounceInput extends React.PureComponent {
       debounceOptions: debounceOptionsCurrent
     } = this.props;
     if (
-      debounceTimeout !== debounceTimeoutCurrent || 
+      debounceTimeout !== debounceTimeoutCurrent ||
       debounceOptions !== debounceOptionsCurrent
     ) {
       this.createNotifier(debounceTimeout, debounceOptions);

--- a/src/Component.js
+++ b/src/Component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
+import shallowequal from 'shallowequal';
 
 
 export class DebounceInput extends React.PureComponent {
@@ -71,7 +72,8 @@ export class DebounceInput extends React.PureComponent {
     } = this.props;
     if (
       debounceTimeout !== debounceTimeoutCurrent ||
-      debounceOptions !== debounceOptionsCurrent
+      debounceOptions !== debounceOptionsCurrent ||
+      !shallowequal(debounceOptions, debounceOptionsCurrent)
     ) {
       this.createNotifier(debounceTimeout, debounceOptions);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5136,6 +5136,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallowequal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
This PR is for #93 and it works very well for my own use case.

I tried my best to make changes with minimal impact. Tests were done manually with my own project, no test code or example was written.

Perhaps a separate property per option would be preferred, however I chose passing a single object so that there's only one extra strict comparison to make in `componentWillReceiveProps` and also because it's less work to pass the options directly to `debounce()`, which already takes care of the case where `debounceOptions` is undefined.

Thanks! 🎉