### PR TITLE
Adds type for placeholder input

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 /*
- *  check usage examples in ./example/typescript-example.tsx 
+ *  check usage examples in ./example/typescript-example.tsx
  */
 
 import * as React from 'react';
@@ -16,6 +16,7 @@ export type DebounceInputProps<WrappedComponent, WrappedComponentProps> = Wrappe
   readonly onKeyDown?: React.KeyboardEventHandler<WrappedComponent>;
   readonly onBlur?: React.FocusEventHandler<WrappedComponent>;
   readonly value?: string | number;
+  readonly placeholder?: string | number;
   readonly minLength?: number;
   readonly debounceTimeout?: number;
   readonly forceNotifyByEnter?: boolean;


### PR DESCRIPTION
This PR adds a type for `placeholder` input.

When converting a project to Typescript I was getting this Typescript compile error:

```
Property 'placeholder' does not exist on type 'IntrinsicAttributes & 
IntrinsicClassAttributes<Component<ThemedOuterStyledProps<WithOptionalTheme...'.
```

In order to resolve I added a type for `placeholder` in `index.d.ts`. I thought others using Typescript might benefit from this change so am opening a PR for your consideration.