### PR TITLE
Update README.md (Correct default value of minLength from 2 to 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Function called when value is changed (debounced) with original event passed thr
 Value of the Input box. Can be omitted, so component works as usual non-controlled input.
 
 
-### `minLength`: PropTypes.number (default: 2)
+### `minLength`: PropTypes.number (default: 0)
 
 Minimal length of text to start notify, if value becomes shorter then `minLength` (after removing some characters), there will be a notification with empty value `''`.
 


### PR DESCRIPTION
Correct default value of minLength from 2 to 0
https://github.com/nkbt/react-debounce-input/blob/7133c62bbab7a44d0e18247dfc431bf75b4595ae/src/Component.js#L31