### PR TITLE
External validation misrender

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -4,6 +4,7 @@ import {Customizable} from './Customizable';
 import {UndoRedo} from './UndoRedo';
 import {Textarea} from './Textarea';
 import {Ref} from './Ref';
+import {MinMax} from './MinMax';
 import {DefaultValue} from './DefaultValue';
 
 
@@ -40,6 +41,12 @@ export function App() {
         <h2>Example 6. Create with default value</h2>
         <DefaultValue />
       </section>
+
+        <section className="section">
+            <h2>Example 7. With External Validation</h2>
+            <MinMax />
+            <p>Accepts values between 10 and 100</p>
+        </section>
     </div>
   );
 }

--- a/example/App.js
+++ b/example/App.js
@@ -42,11 +42,11 @@ export function App() {
         <DefaultValue />
       </section>
 
-        <section className="section">
-            <h2>Example 7. With External Validation</h2>
-            <MinMax />
-            <p>Accepts values between 10 and 100</p>
-        </section>
+      <section className="section">
+        <h2>Example 7. With External Validation</h2>
+        <MinMax />
+        <p>Accepts values between 10 and 100</p>
+      </section>
     </div>
   );
 }

--- a/example/MinMax.js
+++ b/example/MinMax.js
@@ -3,42 +3,42 @@ import {DebounceInput} from '../src';
 
 
 export class MinMax extends React.Component {
-    state = {
-        value: null
+  state = {
+    value: null
+  };
+
+  render() {
+    const {value} = this.state;
+
+    const min = 10;
+    const max = 100;
+
+    const handleChange = e => {
+      let newValue = Number(e.target.value);
+      if (newValue === 0) {
+        newValue = null;
+      } else if (newValue < min) {
+        newValue = min;
+      } else if (newValue > max) {
+        newValue = max;
+      }
+      this.setState({value: newValue});
     };
 
-    render() {
-        const {value} = this.state;
-
-        const min = 10;
-        const max = 100;
-
-        const handleChange = (e) => {
-            let newValue = Number(e.target.value);
-            if (newValue === 0) {
-                newValue = null;
-            } else if (newValue < min) {
-                newValue = min;
-            } else if (newValue > max) {
-                newValue = max;
-            }
-            this.setState({value: newValue});
-        }
-
-        return (
-            <div>
-              <div className="config">
-                <DebounceInput
-                    className="input"
-                    type="number"
-                    min={min}
-                    max={max}
-                    value={value}
-                    debounceTimeout={500}
-                    onChange={handleChange} />
-                <p>Value: {JSON.stringify(value)}</p>
-              </div>
-            </div>
-        );
-    }
+    return (
+      <div>
+        <div className="config">
+          <DebounceInput
+            className="input"
+            type="number"
+            min={min}
+            max={max}
+            value={value}
+            debounceTimeout={500}
+            onChange={handleChange} />
+          <p>Value: {JSON.stringify(value)}</p>
+        </div>
+      </div>
+    );
+  }
 }

--- a/example/MinMax.js
+++ b/example/MinMax.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {DebounceInput} from '../src';
+
+
+export class MinMax extends React.Component {
+    state = {
+        value: null
+    };
+
+    render() {
+        const {value} = this.state;
+
+        const min = 10;
+        const max = 100;
+
+        const handleChange = (e) => {
+            let newValue = Number(e.target.value);
+            if (newValue === 0) {
+                newValue = null;
+            } else if (newValue < min) {
+                newValue = min;
+            } else if (newValue > max) {
+                newValue = max;
+            }
+            this.setState({value: newValue});
+        }
+
+        return (
+            <div>
+              <div className="config">
+                <DebounceInput
+                    className="input"
+                    type="number"
+                    min={min}
+                    max={max}
+                    value={value}
+                    debounceTimeout={500}
+                    onChange={handleChange} />
+                <p>Value: {JSON.stringify(value)}</p>
+              </div>
+            </div>
+        );
+    }
+}

--- a/src/Component.js
+++ b/src/Component.js
@@ -53,7 +53,7 @@ export class DebounceInput extends React.PureComponent {
     }
     const {value, debounceTimeout} = this.props;
 
-    const {debounceTimeout: oldTimeout, value: oldValue} = prevProps;
+    const {debounceTimeout: oldTimeout} = prevProps;
     const {value: stateValue} = this.state;
 
     if (typeof value !== 'undefined' && stateValue !== value) {

--- a/src/Component.js
+++ b/src/Component.js
@@ -56,7 +56,7 @@ export class DebounceInput extends React.PureComponent {
     const {debounceTimeout: oldTimeout, value: oldValue} = prevProps;
     const {value: stateValue} = this.state;
 
-    if (typeof value !== 'undefined' && oldValue !== value && stateValue !== value) {
+    if (typeof value !== 'undefined' && stateValue !== value) {
       // Update state.value if new value passed via props, yep re-render should happen
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({value});
@@ -78,8 +78,9 @@ export class DebounceInput extends React.PureComponent {
     event.persist();
 
     const {value: oldValue} = this.state;
-    const {minLength} = this.props;
+    const {debounceTimeout, minLength} = this.props;
 
+    if (debounceTimeout > 0) this.isDebouncing = true;
     this.setState({value: event.target.value}, () => {
       const {value} = this.state;
 
@@ -132,7 +133,6 @@ export class DebounceInput extends React.PureComponent {
       }, debounceTimeout);
 
       this.notify = event => {
-        this.isDebouncing = true;
         debouncedChangeFunc(event);
       };
 


### PR DESCRIPTION
In reference to issue #130 

It was [the check we discussed](https://github.com/nkbt/react-debounce-input/blob/master/src/Component.js#L59), but not for the reason I thought. 

Since migrating from `componentWillReceiveProps` to `componentDidUpdate` the initial state update on the first keypress is being processed before the `isDebouncing` flag is set.

Previously, the debouncing flag was getting set before the render occurred, but now it is happening earlier, so I expect you were experiencing difficulty and stuttered renders.

In order to combat hitting a check that the `isDebouncing` flag was intended to avoid, an additional check was added that causes the undesirable rendering behavior.

To mitigate, I set it up to conditionally set the `isDebouncing` flag (if denouncing is necessary when calling `this.notify`) before we set the initial state.

As far as I can tell, all of the current examples appear to work perfectly and skipping that extra render appears to slightly improve performance as well. (Though I'm no expert in profiling react apps 😀). I also added another example to demonstrate using the input in the context of external validation that can correct the value.