### PR TITLE
add fragment wrapper on component

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -210,13 +210,13 @@ export class DebounceInput extends React.PureComponent {
 
     const maybeRef = inputRef ? {ref: inputRef} : {};
 
-    return React.createElement(element, {
+    return (React.createElement(element, {
       ...props,
       onChange: this.onChange,
       value,
       ...maybeOnKeyDown,
       ...maybeOnBlur,
       ...maybeRef
-    });
+    }));
   }
 }


### PR DESCRIPTION
Typescript complains with "cannot be used as a JSX component" because it thinks that component returns multiply elements. By just adding parenthesis around return, problem solved.